### PR TITLE
Fixed range error when creating server without join permission

### DIFF
--- a/bin/prompt_chat.dart
+++ b/bin/prompt_chat.dart
@@ -33,7 +33,8 @@ void runApp(ChatAPI api) async {
           {
             await api.loginUser(ccs[1], ccs[2]);
             currUsername = ccs[1];
-            print("\x1B[92m✔️  Login Successful!\n✨ Welcome, \x1B[96m$currUsername!\x1B[0m 🚀");
+            print(
+                "\x1B[92m✔️  Login Successful!\n✨ Welcome, \x1B[96m$currUsername!\x1B[0m 🚀");
             break;
           }
         case "logout":
@@ -62,7 +63,8 @@ void runApp(ChatAPI api) async {
           }
         case "create-server":
           {
-            await api.createServer(ccs[1], currUsername, ccs[2]);
+            await api.createServer(
+                ccs[1], currUsername, ccs.elementAtOrNull(2));
             print("Created server succesfully");
             break;
           }


### PR DESCRIPTION
### Related Issue  
Closes #70 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
The user can create a server without specifying join permission and default value of open is used for it.
