### PR TITLE
Fixed error - invalid salt length #57

### DIFF
--- a/lib/prompt_chat.dart
+++ b/lib/prompt_chat.dart
@@ -39,8 +39,8 @@ class ChatAPI {
     validUsername(username);
     var newUser = User(username, password, false);
 
-    users.add(newUser);
     await newUser.register();
+    users.add(newUser);
   }
 
   void validUsername(String username) {


### PR DESCRIPTION
### Related Issue  
Closes #57 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
When the user logout of the app, stop the app and then login again after starting the app again, error is thrown regarding invalid salt length. This was due to the fact that the password field of the user had conflicts with the in memory cache and the db.

### Implementation Details  
Made sure that the user is added to in memory cache with the hashed password.
