### PR TITLE
Fixed duplication of categories #80

### DIFF
--- a/lib/cli/category.dart
+++ b/lib/cli/category.dart
@@ -14,7 +14,7 @@ class Category {
 
   static Category fromMap(Map<String, dynamic> map) {
     late List<Channel> unmappedChannels;
-    if(map['channels'] == null) {
+    if (map['channels'] == null) {
       unmappedChannels = [];
     }
     unmappedChannels = (map['channels'] as List)
@@ -23,4 +23,12 @@ class Category {
     return Category(
         categoryName: map['categoryName'], channels: unmappedChannels);
   }
+
+  @override
+  bool operator ==(Object other) {
+    return other is Category && other.categoryName == categoryName;
+  }
+
+  @override
+  int get hashCode => categoryName.hashCode;
 }


### PR DESCRIPTION
### Related Issue  
Closes #80  

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
The duplication of categories with the same name is avoided. Error is shown to the user when he is trying to add a category which already exists.

### Implementation Details  
Added equality operator to Category which only accounts for the category name so that the .contains() method work as intended.

### Demo
<img width="1252" alt="Screenshot 2025-01-06 at 10 19 35 PM" src="https://github.com/user-attachments/assets/7bdb380f-98f8-4c5e-a6ea-6ad36c41b497" />
