### PR TITLE
Fixed duplication of channels

### DIFF
--- a/lib/cli/channel.dart
+++ b/lib/cli/channel.dart
@@ -1,48 +1,70 @@
 import 'package:prompt_chat/cli/message.dart';
-import 'package:prompt_chat/enum/permissions.dart';
 import 'package:prompt_chat/enum/channel_type.dart';
-
+import 'package:prompt_chat/enum/permissions.dart';
 
 class Channel {
   late String channelName;
   late Permission permission;
   late ChannelType type;
   List<Message> messages = [];
-  Channel({required this.channelName, required this.messages, required this.type, this.permission = Permission.member});
+  Channel(
+      {required this.channelName,
+      required this.messages,
+      required this.type,
+      this.permission = Permission.member});
   Map<String, dynamic> toMap() {
     var mappedMessages = messages.map((message) => message.toMap()).toList();
     return {
-      'channelName' : channelName,
-      'permission' : permission.toString(),
-      'channelType' : type.toString(),
-      'messages' : mappedMessages,
-      'finder' : "finder",
+      'channelName': channelName,
+      'permission': permission.toString(),
+      'channelType': type.toString(),
+      'messages': mappedMessages,
+      'finder': "finder",
     };
   }
+
   static Channel fromMap(Map<String, dynamic> map) {
     late Permission perm;
     late ChannelType chanType;
-    if(map['permission'] == "Permission.owner") {
+    if (map['permission'] == "Permission.owner") {
       perm = Permission.owner;
     }
-    if(map['permission'] == "Permission.moderator") {
+    if (map['permission'] == "Permission.moderator") {
       perm = Permission.moderator;
-    } 
-    if(map['permission'] == "Permission.member") {
+    }
+    if (map['permission'] == "Permission.member") {
       perm = Permission.member;
     }
-    if(map['channelType'] == "ChannelType.text") {
+    if (map['channelType'] == "ChannelType.text") {
       chanType = ChannelType.text;
     }
-    if(map['channelType'] == "ChannelType.voice") {
+    if (map['channelType'] == "ChannelType.voice") {
       chanType = ChannelType.voice;
     }
-    if(map['channelType'] == "ChannelType.video") {
+    if (map['channelType'] == "ChannelType.video") {
       chanType = ChannelType.video;
     }
-    var unmappedMessages = (map['messages'] as List).map((message) => Message.fromMap(message)).toList();
+    var unmappedMessages = (map['messages'] as List)
+        .map((message) => Message.fromMap(message))
+        .toList();
 
-    return Channel(channelName: map['channelName'], messages: unmappedMessages, type: chanType, permission: perm);
+    return Channel(
+        channelName: map['channelName'],
+        messages: unmappedMessages,
+        type: chanType,
+        permission: perm);
   }
 
+  @override
+  bool operator ==(Object other) {
+    return other is Channel &&
+        other.channelName == channelName &&
+        other.permission == permission &&
+        other.type == type;
+  }
+
+  @override
+  int get hashCode {
+    return channelName.hashCode ^ permission.hashCode ^ type.hashCode;
+  }
 }


### PR DESCRIPTION
### Related Issue  
Closes #82 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:   
- [x] Bug Fix  

### Description of Change  
Duplicate channels are forbidden to be created. Duplicate here means a channel having the same name, join permission and type.

### Implementation Details  
Added equality operator to the Channel model using only name, permission and type.

### Demo
<img width="1267" alt="Screenshot 2025-01-06 at 10 16 51 PM" src="https://github.com/user-attachments/assets/a7f717f8-7d80-45fe-adcb-2f2ba93a5044" />

